### PR TITLE
Fix faulty behavior

### DIFF
--- a/src/frame/reader.rs
+++ b/src/frame/reader.rs
@@ -53,7 +53,10 @@ impl<R: BlockRead + Unpin> FrameReader<R> {
         if !need_to_skip_block {
             return Ok(());
         }
-        self.reader.next_block().await?;
+        if !self.reader.next_block().await? {
+            return Err(ReadFrameError::NotAvailable);
+        }
+
         self.cursor = 0;
         self.block_corrupted = false;
         Ok(())

--- a/src/multi_record_log.rs
+++ b/src/multi_record_log.rs
@@ -87,8 +87,13 @@ impl MultiRecordLog {
                     MultiPlexedRecord::AppendRecords {
                         queue,
                         records,
-                        position: _,
+                        position,
                     } => {
+                        if !in_mem_queues.contains_queue(queue) {
+                            in_mem_queues
+                                .touch(queue, position, &file_number)
+                                .map_err(|_| ReadRecordError::Corruption)?;
+                        }
                         for record in records {
                             let (position, payload) = record?;
                             in_mem_queues

--- a/src/proptests.rs
+++ b/src/proptests.rs
@@ -11,14 +11,16 @@ use crate::record::{MultiPlexedRecord, MultiRecord};
 use crate::{MultiRecordLog, Serializable};
 
 struct PropTestEnv {
-    tempdir: TempDir,
+    tempdir: std::mem::ManuallyDrop<TempDir>,
     record_log: MultiRecordLog,
     state: HashMap<&'static str, Range<u64>>,
+    block_to_write: Vec<u8>,
 }
 
 impl PropTestEnv {
-    pub async fn new() -> Self {
+    pub async fn new(block_size: usize) -> Self {
         let tempdir = tempfile::tempdir().unwrap();
+        eprintln!("testpath: {}", tempdir.path().display());
         let mut record_log = MultiRecordLog::open(tempdir.path()).await.unwrap();
         record_log.create_queue("q1").await.unwrap();
         record_log.create_queue("q2").await.unwrap();
@@ -26,9 +28,10 @@ impl PropTestEnv {
         state.insert("q1", 0..0);
         state.insert("q2", 0..0);
         PropTestEnv {
-            tempdir,
+            tempdir: std::mem::ManuallyDrop::new(tempdir),
             record_log,
             state,
+            block_to_write: vec![b'A'; block_size],
         }
     }
 
@@ -36,9 +39,6 @@ impl PropTestEnv {
         match op {
             Operation::Reopen => {
                 self.reload().await;
-            }
-            Operation::Append { queue } => {
-                self.append(queue).await;
             }
             Operation::MultiAppend { queue, count } => {
                 self.multi_append(queue, count).await;
@@ -62,26 +62,12 @@ impl PropTestEnv {
         }
     }
 
-    pub async fn append(&mut self, queue: &str) {
-        let range = self.state.get_mut(queue).unwrap();
-
-        let res = self
-            .record_log
-            .append_record(queue, Some(range.end), &[])
-            .await
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(range.end, res);
-        range.end += 1;
-    }
-
     pub async fn double_append(&mut self, queue: &str) {
         let range = self.state.get_mut(queue).unwrap();
 
         let res = self
             .record_log
-            .append_record(queue, Some(range.end), &[])
+            .append_record(queue, Some(range.end), &b"BB"[..])
             .await
             .unwrap()
             .unwrap();
@@ -105,7 +91,7 @@ impl PropTestEnv {
             .append_records(
                 queue,
                 Some(range.end),
-                std::iter::repeat(&b""[..]).take(count as usize),
+                std::iter::repeat(&self.block_to_write[..]).take(count as usize),
             )
             .await
             .unwrap();
@@ -140,7 +126,6 @@ fn queue_strategy() -> impl Strategy<Value = &'static str> {
 fn operation_strategy() -> impl Strategy<Value = Operation> {
     prop_oneof![
         Just(Operation::Reopen),
-        queue_strategy().prop_map(|queue| Operation::Append { queue }),
         queue_strategy().prop_map(|queue| Operation::RedundantAppend { queue }),
         (queue_strategy(), (0u64..10u64))
             .prop_map(|(queue, pos)| Operation::Truncate { queue, pos }),
@@ -164,11 +149,50 @@ fn random_multi_record_strategy(
     prop::collection::vec(random_bytevec_strategy(max_len), 1..max_record_count)
 }
 
+#[test]
+fn test_scenario_end_on_full_file() {
+    use Operation::*;
+    let ops = [
+        MultiAppend {
+            queue: "q1",
+            count: 1,
+        },
+        MultiAppend {
+            queue: "q1",
+            count: 1,
+        },
+        MultiAppend {
+            queue: "q2",
+            count: 1,
+        },
+        MultiAppend {
+            queue: "q2",
+            count: 1,
+        },
+        MultiAppend {
+            queue: "q2",
+            count: 1,
+        },
+        Reopen,
+        RedundantAppend { queue: "q2" },
+        Reopen,
+    ];
+    Runtime::new().unwrap().block_on(async {
+        // this value is crafted to make so exactly two full files are stored,
+        // but no 3rd is created: if anything about the format change, this test
+        // will become useless (but won't fail spuriously).
+        let mut env = PropTestEnv::new(52381).await;
+        for op in ops {
+            env.apply(op).await;
+        }
+    });
+}
+
 proptest::proptest! {
     #[test]
-    fn test_proptest_multirecord(ops in operations_strategy()) {
+    fn test_proptest_multirecord((ops, block_size) in (operations_strategy(), 0usize..65535)) {
         Runtime::new().unwrap().block_on(async {
-            let mut env = PropTestEnv::new().await;
+            let mut env = PropTestEnv::new(block_size).await;
             for op in ops {
                 env.apply(op).await;
             }
@@ -217,7 +241,6 @@ proptest::proptest! {
 #[derive(Debug, Clone)]
 enum Operation {
     Reopen,
-    Append { queue: &'static str },
     MultiAppend { queue: &'static str, count: u64 },
     RedundantAppend { queue: &'static str },
     Truncate { queue: &'static str, pos: u64 },

--- a/src/rolling/directory.rs
+++ b/src/rolling/directory.rs
@@ -127,7 +127,7 @@ impl RollingReader {
             file,
             directory,
             file_number: first_file.clone(),
-            block_id: 0,
+            block_id: 1,
             block,
         })
     }
@@ -140,7 +140,7 @@ impl RollingReader {
     ///
     /// If no block was read, positions itself at the beginning.
     pub async fn into_writer(mut self) -> io::Result<RollingWriter> {
-        let offset = self.block_id * crate::BLOCK_NUM_BYTES;
+        let offset = (self.block_id - 1) * crate::BLOCK_NUM_BYTES;
         self.file.seek(SeekFrom::Start(offset as u64)).await?;
         Ok(RollingWriter {
             file: BufWriter::with_capacity(FRAME_NUM_BYTES, self.file),
@@ -182,7 +182,7 @@ impl BlockRead for RollingReader {
             let mut next_file: File = self.directory.open_file(&next_file_number).await?;
             let success = read_block(&mut next_file, &mut self.block).await?;
             if success {
-                self.block_id += 1;
+                self.block_id = 1;
                 self.file = next_file;
                 self.file_number = next_file_number;
                 return Ok(true);


### PR DESCRIPTION
while testing some more, I found new issues when storing larger records. The proptests used short records so it rarely caused more than one block to be used, and never more than one file.

This enhance proptests to choose themselves the size of records they want to test, and fix the few bugs it uncovered

I believe this finish fixing #1 