### PR TITLE
add benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,8 @@ tempfile = "3"
 futures = "0.3"
 rand = "0.8"
 proptest = "1"
+criterion = { version = "0.4", features = ["async_tokio"] }
 
+[[bench]]
+name = "bench"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,54 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use mrecordlog::MultiRecordLog;
+
+async fn bench_single_size(size: usize, count: usize, loop_count: usize) {
+    let tempdir = tempfile::tempdir().unwrap();
+    let mut record_log = MultiRecordLog::open(tempdir.path()).await.unwrap();
+    record_log.create_queue("q1").await.unwrap();
+
+    let record = vec![0; size];
+
+    for _ in 0..loop_count {
+        record_log
+            .append_records("q1", None, std::iter::repeat(&record[..]).take(count))
+            .await
+            .unwrap();
+    }
+}
+
+fn insert_throughput(c: &mut Criterion) {
+    let record_sizes: [usize; 2] = [1 << 8, 1 << 14];
+    let record_counts: [usize; 3] = [1, 16, 256];
+    let bytes_written: usize = 1 << 22;
+
+    let mut group = c.benchmark_group("insert speed");
+    group.throughput(criterion::Throughput::Bytes(bytes_written as _));
+
+    for record_size in record_sizes {
+        for record_count in record_counts {
+            if record_size * record_count > bytes_written {
+                continue;
+            }
+            let loop_count = bytes_written / record_count / record_size;
+
+            group.bench_with_input(
+                BenchmarkId::new(
+                    "bench_append_throughput",
+                    format!("size={},count={}", record_size, record_count),
+                ),
+                &(record_size, record_count, loop_count),
+                |b, (record_size, record_count, loop_count)| {
+                    let runtime = tokio::runtime::Builder::new_multi_thread()
+                        .enable_all()
+                        .build()
+                        .unwrap();
+                    b.to_async(runtime)
+                        .iter(|| bench_single_size(*record_size, *record_count, *loop_count));
+                },
+            );
+        }
+    }
+}
+
+criterion_group!(benches, insert_throughput);
+criterion_main!(benches);


### PR DESCRIPTION
I was under the impression things were not as fast as I'd like. It's in fact only a problem with short records inserted in small groups (with default policy, it issues a lot of fsync)

|record count\\record size | 256B             | 16kiB             |
|----------------------------------|-------------------|-------------------|
| 1                                      | 21.724 MiB/s | 458.28 MiB/s |
| 16                                    | 273.90 MiB/s | 750.97 MiB/s |
| 256                                  | 604.79 MiB/s | 511.02 MiB/s |
