### PR TITLE
update last_touch on append

### DIFF
--- a/src/mem/queue.rs
+++ b/src/mem/queue.rs
@@ -109,7 +109,7 @@ impl MemQueue {
         if idx >= self.record_metas.len() {
             return None;
         }
-        Some(idx as usize)
+        Some(idx)
     }
 
     pub fn range<R>(&self, range: R) -> impl Iterator<Item = (u64, &[u8])> + '_

--- a/src/mem/queue.rs
+++ b/src/mem/queue.rs
@@ -17,16 +17,16 @@ pub struct MemQueue {
     concatenated_records: Vec<u8>,
     start_position: u64,
     record_metas: Vec<RecordMeta>,
-    last_touch: Option<FileNumber>,
+    last_update: Option<FileNumber>,
 }
 
 impl MemQueue {
-    pub fn with_next_position(next_position: u64, last_touch: FileNumber) -> Self {
+    pub fn with_next_position(next_position: u64, last_update: FileNumber) -> Self {
         MemQueue {
             concatenated_records: Vec::new(),
             start_position: next_position,
             record_metas: Vec::new(),
-            last_touch: Some(last_touch),
+            last_update: Some(last_update),
         }
     }
 
@@ -37,11 +37,11 @@ impl MemQueue {
     ) -> Result<(), TouchError> {
         if self.is_empty() && self.start_position == 0 {
             self.start_position = start_position;
-            self.last_touch = Some(file_number.clone());
+            self.last_update = Some(file_number.clone());
             return Ok(());
         }
         if self.start_position == start_position {
-            self.last_touch = Some(file_number.clone());
+            self.last_update = Some(file_number.clone());
             return Ok(());
         }
         Err(TouchError)
@@ -87,6 +87,10 @@ impl MemQueue {
         } else {
             file_number.clone()
         };
+
+        if self.last_update.as_ref() != Some(&file_number) {
+            self.last_update = Some(file_number.clone());
+        }
 
         let record_meta = RecordMeta {
             start_offset: self.concatenated_records.len(),

--- a/src/mem/tests.rs
+++ b/src/mem/tests.rs
@@ -153,7 +153,7 @@ fn test_mem_queues_non_zero_first_el() {
 fn test_mem_queues_kee_filenum() {
     let mut mem_queues = MemQueues::default();
 
-    let files = (0..3)
+    let files = (0..4)
         .into_iter()
         .map(FileNumber::for_test)
         .collect::<Vec<_>>();
@@ -207,5 +207,14 @@ fn test_mem_queues_kee_filenum() {
 
     mem_queues.truncate("droopy", 4);
 
+    assert!(!files[2].can_be_deleted());
+
+    let empty_queues = mem_queues.empty_queues().collect::<Vec<_>>();
+    assert_eq!(empty_queues.len(), 1);
+    assert_eq!(empty_queues[0].0, "droopy");
+
+    mem_queues.touch("droopy", 5, &files[3]).unwrap();
+
     assert!(files[2].can_be_deleted());
+    assert!(!files[3].can_be_deleted());
 }

--- a/src/proptests.rs
+++ b/src/proptests.rs
@@ -277,7 +277,7 @@ enum Operation {
 #[tokio::test]
 async fn test_multi_record() {
     let tempdir = tempfile::tempdir().unwrap();
-    eprintln!("dir={:?}", tempdir);
+    eprintln!("dir={tempdir:?}");
     {
         let mut multi_record_log = MultiRecordLog::open(tempdir.path()).await.unwrap();
         multi_record_log.create_queue("queue").await.unwrap();

--- a/src/recordlog/tests.rs
+++ b/src/recordlog/tests.rs
@@ -102,7 +102,7 @@ async fn test_first_chunk_empty() {
 
 #[tokio::test]
 async fn test_behavior_upon_corruption() {
-    let records: Vec<String> = (0..1_000).map(|i| format!("hello{}", i)).collect();
+    let records: Vec<String> = (0..1_000).map(|i| format!("hello{i}")).collect();
     let mut writer = RecordWriter::in_memory();
     for record in &records {
         writer.write_record(record.as_str()).await.unwrap();

--- a/src/rolling/directory.rs
+++ b/src/rolling/directory.rs
@@ -33,7 +33,7 @@ fn filename_to_position(file_name: &str) -> Option<u64> {
 }
 
 pub(crate) fn filepath(dir: &Path, file_number: &FileNumber) -> PathBuf {
-    dir.join(&file_number.filename())
+    dir.join(file_number.filename())
 }
 
 async fn create_file(dir_path: &Path, file_number: &FileNumber) -> io::Result<File> {

--- a/src/rolling/tests.rs
+++ b/src/rolling/tests.rs
@@ -134,7 +134,7 @@ async fn test_directory_simple() {
             .into_writer()
             .await
             .unwrap();
-        let buf = vec![1u8; FRAME_NUM_BYTES as usize];
+        let buf = vec![1u8; FRAME_NUM_BYTES];
         for _ in 0..(NUM_BLOCKS_PER_FILE + 1) {
             writer.write(&buf).await.unwrap();
         }
@@ -158,7 +158,7 @@ async fn test_directory_truncate() {
         file_0 = reader.current_file().clone();
         assert!(!file_0.can_be_deleted());
         let mut writer: RollingWriter = reader.into_writer().await.unwrap();
-        let buf = vec![1u8; FRAME_NUM_BYTES as usize];
+        let buf = vec![1u8; FRAME_NUM_BYTES];
         assert_eq!(&writer.current_file().unroll(&writer.directory.files), &[0]);
         for _ in 0..NUM_BLOCKS_PER_FILE + 1 {
             writer.write(&buf).await.unwrap();


### PR DESCRIPTION
fix a bug where the on disk queue would never get gc-ed if we never touch a queue (because it's never empty for instance)