### PR TITLE
make truncating queue faster

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         multi_record_log.create_queue("q").await?;
     }
     for (_line, payload) in multi_record_log.range("q", ..).unwrap() {
-        let line_utf8 = std::str::from_utf8(payload).unwrap();
+        let line_utf8 = std::str::from_utf8(&payload).unwrap();
         println!("BEFORE {line_utf8}");
     }
     while let Some(line) = lines.next_line().await? {

--- a/src/mem/queues.rs
+++ b/src/mem/queues.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::RangeBounds;
 
@@ -43,7 +44,7 @@ impl MemQueues {
         &self,
         queue: &str,
         range: R,
-    ) -> Option<impl Iterator<Item = (u64, &[u8])> + '_>
+    ) -> Option<impl Iterator<Item = (u64, Cow<[u8]>)> + '_>
     where
         R: RangeBounds<u64> + 'static,
     {

--- a/src/mem/tests.rs
+++ b/src/mem/tests.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use super::*;
 use crate::error::{AlreadyExists, AppendError};
 use crate::rolling::FileNumber;
@@ -44,16 +46,20 @@ fn test_mem_queues() {
             .is_ok());
         assert_eq!(
             mem_queues.range("droopy", 0..).unwrap().next(),
-            Some((0, &b"hello"[..]))
+            Some((0, Cow::Borrowed(&b"hello"[..])))
         );
-        let droopy: Vec<(u64, &[u8])> = mem_queues.range("droopy", 1..).unwrap().collect();
+        let droopy: Vec<(u64, Cow<[u8]>)> = mem_queues.range("droopy", 1..).unwrap().collect();
         assert_eq!(
             &droopy,
-            &[(1, &b"happy"[..]), (2, &b"tax"[..]), (3, &b"payer"[..])],
+            &[
+                (1, Cow::Borrowed(&b"happy"[..])),
+                (2, Cow::Borrowed(&b"tax"[..])),
+                (3, Cow::Borrowed(&b"payer"[..]))
+            ],
         );
     }
-    let fable: Vec<(u64, &[u8])> = mem_queues.range("fable", 1..).unwrap().collect();
-    assert_eq!(&fable, &[(1, &b"corbeau"[..])]);
+    let fable: Vec<(u64, Cow<[u8]>)> = mem_queues.range("fable", 1..).unwrap().collect();
+    assert_eq!(&fable, &[(1, Cow::Borrowed(&b"corbeau"[..]))]);
 }
 
 #[test]
@@ -81,8 +87,14 @@ fn test_mem_queues_truncate() {
             .unwrap();
     }
     mem_queues.truncate("droopy", 3);
-    let droopy: Vec<(u64, &[u8])> = mem_queues.range("droopy", 0..).unwrap().collect();
-    assert_eq!(&droopy[..], &[(4, &b"!"[..]), (5, &b"payer"[..]),]);
+    let droopy: Vec<(u64, Cow<[u8]>)> = mem_queues.range("droopy", 0..).unwrap().collect();
+    assert_eq!(
+        &droopy[..],
+        &[
+            (4, Cow::Borrowed(&b"!"[..])),
+            (5, Cow::Borrowed(&b"payer"[..])),
+        ]
+    );
 }
 
 #[test]
@@ -101,8 +113,14 @@ fn test_mem_queues_skip_yield_error() {
     assert!(mem_queues
         .append_record("droopy", &1.into(), 1, b"happy")
         .is_ok());
-    let droopy: Vec<(u64, &[u8])> = mem_queues.range("droopy", 0..).unwrap().collect();
-    assert_eq!(&droopy[..], &[(0, &b"hello"[..]), (1, &b"happy"[..])]);
+    let droopy: Vec<(u64, Cow<[u8]>)> = mem_queues.range("droopy", 0..).unwrap().collect();
+    assert_eq!(
+        &droopy[..],
+        &[
+            (0, Cow::Borrowed(&b"hello"[..])),
+            (1, Cow::Borrowed(&b"happy"[..]))
+        ]
+    );
 }
 
 #[test]
@@ -134,8 +152,8 @@ fn test_mem_queues_append_idempotence() {
             .unwrap_err(),
         AppendError::Past
     ));
-    let droopy: Vec<(u64, &[u8])> = mem_queues.range("droopy", 0..).unwrap().collect();
-    assert_eq!(&droopy, &[(0, &b"hello"[..])]);
+    let droopy: Vec<(u64, Cow<[u8]>)> = mem_queues.range("droopy", 0..).unwrap().collect();
+    assert_eq!(&droopy, &[(0, Cow::Borrowed(&b"hello"[..]))]);
 }
 
 #[test]
@@ -145,8 +163,8 @@ fn test_mem_queues_non_zero_first_el() {
     assert!(mem_queues
         .append_record("droopy", &1.into(), 5, b"hello")
         .is_ok());
-    let droopy: Vec<(u64, &[u8])> = mem_queues.range("droopy", 0..).unwrap().collect();
-    assert_eq!(droopy, &[(5, &b"hello"[..])]);
+    let droopy: Vec<(u64, Cow<[u8]>)> = mem_queues.range("droopy", 0..).unwrap().collect();
+    assert_eq!(droopy, &[(5, Cow::Borrowed(&b"hello"[..]))]);
 }
 
 #[test]

--- a/src/multi_record_log.rs
+++ b/src/multi_record_log.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::io;
 use std::ops::RangeBounds;
 use std::path::Path;
@@ -262,7 +263,7 @@ impl MultiRecordLog {
         &self,
         queue: &str,
         range: R,
-    ) -> Option<impl Iterator<Item = (u64, &[u8])> + '_>
+    ) -> Option<impl Iterator<Item = (u64, Cow<[u8]>)> + '_>
     where
         R: RangeBounds<u64> + 'static,
     {

--- a/src/proptests.rs
+++ b/src/proptests.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::Range;
 
@@ -307,7 +308,7 @@ async fn test_multi_record() {
                 .range("queue", ..)
                 .unwrap()
                 .collect::<Vec<_>>(),
-            [(1, &b"22"[..])],
+            [(1, Cow::Borrowed(&b"22"[..]))],
         );
     }
     {
@@ -327,7 +328,10 @@ async fn test_multi_record() {
                 .range("queue", ..)
                 .unwrap()
                 .collect::<Vec<_>>(),
-            [(1, &b"22"[..]), (2, &b"hello"[..]),]
+            [
+                (1, Cow::Borrowed(&b"22"[..])),
+                (2, Cow::Borrowed(&b"hello"[..])),
+            ]
         );
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
+
 use crate::MultiRecordLog;
 
-fn read_all_records<'a>(multi_record_log: &'a MultiRecordLog, queue: &str) -> Vec<&'a [u8]> {
+fn read_all_records<'a>(multi_record_log: &'a MultiRecordLog, queue: &str) -> Vec<Cow<'a, [u8]>> {
     let mut records = Vec::new();
     let mut next_pos = u64::default();
     for (pos, payload) in multi_record_log.range(queue, next_pos..).unwrap() {
@@ -281,7 +283,7 @@ async fn test_truncate_range_correct_pos() {
                 .range("queue", ..)
                 .unwrap()
                 .collect::<Vec<_>>(),
-            &[(2, &b"3"[..])]
+            &[(2, Cow::Borrowed(&b"3"[..]))]
         );
 
         assert_eq!(
@@ -289,7 +291,7 @@ async fn test_truncate_range_correct_pos() {
                 .range("queue", 2..)
                 .unwrap()
                 .collect::<Vec<_>>(),
-            &[(2, &b"3"[..])]
+            &[(2, Cow::Borrowed(&b"3"[..]))]
         );
 
         use std::ops::Bound;
@@ -298,7 +300,7 @@ async fn test_truncate_range_correct_pos() {
                 .range("queue", (Bound::Excluded(1), Bound::Unbounded))
                 .unwrap()
                 .collect::<Vec<_>>(),
-            &[(2, &b"3"[..])]
+            &[(2, Cow::Borrowed(&b"3"[..]))]
         );
     }
 }


### PR DESCRIPTION
fix #18 

this replaces a `Vec<u8>` which often get drained from start with a `VecDeque`. Once in a while it requires allocating a temporary Vec when calling `MemQueue::range`, which I wasn't able to spot on flamegraphs, so the impact is negligible. However it makes `MemQueue::truncate` go from ~3.1% of samples to ~0.02% on a Quickwit ingest-only benchmark.

It is probably possible to go faster by using a VecDeque for MemQueue.record_metas, but the impact will likely be negligible given the time currently spent in truncate.