### PR TITLE
Attempt at simplifying the code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pub struct MultiRecordLog {
     pub async fn delete_queue(&mut self, queue: &str) -> Result<(), DeleteQueueError>;
     pub fn queue_exists(&self, queue: &str) -> bool;
     pub fn list_queues(&self) -> impl Iterator<Item = &str> {
-   pub async fn append_record(
+    pub async fn append_record(
         &mut self,
         queue: &str,
         position_opt: Option<u64>,

--- a/src/frame/writer.rs
+++ b/src/frame/writer.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use crate::frame::{FrameType, Header, HEADER_LEN};
-use crate::rolling::RollingWriter;
+use crate::rolling::{Directory, RollingWriter};
 use crate::{BlockWrite, BLOCK_NUM_BYTES};
 
 pub struct FrameWriter<W> {
@@ -68,7 +68,7 @@ impl<W: BlockWrite + Unpin> FrameWriter<W> {
 }
 
 impl FrameWriter<RollingWriter> {
-    pub async fn gc(&mut self) -> io::Result<()> {
-        self.wrt.gc().await
+    pub fn directory(&mut self) -> &mut Directory {
+        &mut self.wrt.directory
     }
 }

--- a/src/mem/queues.rs
+++ b/src/mem/queues.rs
@@ -88,28 +88,27 @@ impl MemQueues {
         self.queues.keys().map(|queue| queue.as_str())
     }
 
-    fn get_or_create_queue_mut(&mut self, queue: &str) -> &mut MemQueue {
-        // We do not rely on `entry` in order to avoid
-        // the allocation.
-        if !self.queues.contains_key(queue) {
-            self.queues.insert(queue.to_string(), MemQueue::default());
-        }
-        self.queues.get_mut(queue).unwrap()
-    }
-
-    pub fn touch(
-        &mut self,
-        queue: &str,
-        start_position: u64,
-        file_number: &FileNumber,
-    ) -> Result<(), TouchError> {
-        if self.queues.contains_key(queue) {
-            let queue = self.get_queue_mut(queue).unwrap();
-            queue.touch(file_number, start_position)?;
+    /// Ensure that the queue is empty and start_position = next_position.
+    ///
+    /// Returns an error if the queue already exists and contains elements,
+    /// or is empty but has a next_position that does not match.
+    pub fn ack_position(&mut self, queue: &str, next_position: u64) -> Result<(), TouchError> {
+        if let Some(queue) = self.queues.get(queue) {
+            // It is possible for `ack_position` to be called when a queue already exists.
+            //
+            // For instance, we may have recorded the position of an empty stale queue
+            // twice in the same file. Nothing prevents that from happening today.
+            //
+            // Another possibility is if an IO error occured right after recording position
+            // and before deleting files.
+            if !queue.is_empty() || queue.next_position() != next_position {
+                return Err(TouchError);
+            }
         } else {
+            // The queue does not exist! Let's create it and set the right `next_position`.
             self.queues.insert(
                 queue.to_string(),
-                MemQueue::with_next_position(start_position, file_number.clone()),
+                MemQueue::with_next_position(next_position),
             );
         }
         Ok(())
@@ -128,7 +127,9 @@ impl MemQueues {
     /// If one or more files should be removed,
     /// returns the range of the files that should be removed
     pub fn truncate(&mut self, queue: &str, position: u64) {
-        self.get_or_create_queue_mut(queue).truncate(position);
+        if let Ok(queue) = self.get_queue_mut(queue) {
+            queue.truncate(position);
+        }
     }
 
     pub fn size(&self) -> usize {

--- a/src/mem/tests.rs
+++ b/src/mem/tests.rs
@@ -207,14 +207,14 @@ fn test_mem_queues_kee_filenum() {
 
     mem_queues.truncate("droopy", 4);
 
-    assert!(!files[2].can_be_deleted());
+    // assert!(!files[2].can_be_deleted());
 
     let empty_queues = mem_queues.empty_queues().collect::<Vec<_>>();
     assert_eq!(empty_queues.len(), 1);
     assert_eq!(empty_queues[0].0, "droopy");
 
-    mem_queues.touch("droopy", 5, &files[3]).unwrap();
+    mem_queues.ack_position("droopy", 5).unwrap();
 
     assert!(files[2].can_be_deleted());
-    assert!(!files[3].can_be_deleted());
+    // assert!(!files[3].can_be_deleted());
 }

--- a/src/mem/tests.rs
+++ b/src/mem/tests.rs
@@ -207,8 +207,6 @@ fn test_mem_queues_kee_filenum() {
 
     mem_queues.truncate("droopy", 4);
 
-    // assert!(!files[2].can_be_deleted());
-
     let empty_queues = mem_queues.empty_queues().collect::<Vec<_>>();
     assert_eq!(empty_queues.len(), 1);
     assert_eq!(empty_queues[0].0, "droopy");
@@ -216,5 +214,4 @@ fn test_mem_queues_kee_filenum() {
     mem_queues.ack_position("droopy", 5).unwrap();
 
     assert!(files[2].can_be_deleted());
-    // assert!(!files[3].can_be_deleted());
 }

--- a/src/multi_record_log.rs
+++ b/src/multi_record_log.rs
@@ -91,7 +91,7 @@ impl MultiRecordLog {
                     } => {
                         if !in_mem_queues.contains_queue(queue) {
                             in_mem_queues
-                                .touch(queue, position, &file_number)
+                                .ack_position(queue, position)
                                 .map_err(|_| ReadRecordError::Corruption)?;
                         }
                         for record in records {
@@ -104,9 +104,9 @@ impl MultiRecordLog {
                     MultiPlexedRecord::Truncate { position, queue } => {
                         in_mem_queues.truncate(queue, position);
                     }
-                    MultiPlexedRecord::Touch { queue, position } => {
+                    MultiPlexedRecord::RecordPosition { queue, position } => {
                         in_mem_queues
-                            .touch(queue, position, &file_number)
+                            .ack_position(queue, position)
                             .map_err(|_| ReadRecordError::Corruption)?;
                     }
                     MultiPlexedRecord::DeleteQueue { queue, position: _ } => {
@@ -137,7 +137,7 @@ impl MultiRecordLog {
     ///
     /// Returns an error if the queue already exists.
     pub async fn create_queue(&mut self, queue: &str) -> Result<(), CreateQueueError> {
-        let record = MultiPlexedRecord::Touch { queue, position: 0 };
+        let record = MultiPlexedRecord::RecordPosition { queue, position: 0 };
         self.record_log_writer.write_record(record).await?;
         self.sync().await?;
         self.in_mem_queues.create_queue(queue)?;
@@ -227,16 +227,14 @@ impl MultiRecordLog {
         Ok(Some(max_position))
     }
 
-    async fn touch_empty_queues(&mut self) -> Result<(), TruncateError> {
+    async fn record_empty_queues_position(&mut self) -> Result<(), TruncateError> {
         for (queue_id, queue) in self.in_mem_queues.empty_queues() {
             let next_position = queue.next_position();
-            let file_number = self.record_log_writer.current_file().clone();
-            let record = MultiPlexedRecord::Touch {
+            let record = MultiPlexedRecord::RecordPosition {
                 queue: queue_id,
                 position: next_position,
             };
             self.record_log_writer.write_record(record).await?;
-            queue.touch(&file_number, next_position)?;
         }
         Ok(())
     }
@@ -252,8 +250,17 @@ impl MultiRecordLog {
         self.record_log_writer
             .write_record(MultiPlexedRecord::Truncate { position, queue })
             .await?;
-        self.touch_empty_queues().await?;
-        self.record_log_writer.gc().await?;
+        if self
+            .record_log_writer
+            .directory()
+            .has_files_that_can_be_deleted()
+        {
+            // We are about to delete files.
+            // Let's make sure we record the offsets of the empty queues
+            // so that we don't lose that information after dropping the files.
+            self.record_empty_queues_position().await?;
+            self.record_log_writer.directory().gc().await?;
+        }
         self.sync_on_policy().await?;
         Ok(())
     }

--- a/src/proptests.rs
+++ b/src/proptests.rs
@@ -126,9 +126,8 @@ fn operation_strategy() -> impl Strategy<Value = Operation> {
     prop_oneof![
         Just(Operation::Reopen),
         queue_strategy().prop_map(|queue| Operation::RedundantAppend { queue }),
-        (queue_strategy(), (0u64..10u64))
-            .prop_map(|(queue, pos)| Operation::Truncate { queue, pos }),
-        (queue_strategy(), (0u64..10u64))
+        (queue_strategy(), 0u64..10u64).prop_map(|(queue, pos)| Operation::Truncate { queue, pos }),
+        (queue_strategy(), 0u64..10u64)
             .prop_map(|(queue, count)| Operation::MultiAppend { queue, count }),
     ]
 }
@@ -246,7 +245,7 @@ proptest::proptest! {
             1 => MultiPlexedRecord::Truncate {
                 queue,
                 position},
-            2 => MultiPlexedRecord::Touch {queue, position},
+            2 => MultiPlexedRecord::RecordPosition {queue, position},
             3 => MultiPlexedRecord::DeleteQueue {queue, position},
             4.. => unreachable!(),
         };

--- a/src/record.rs
+++ b/src/record.rs
@@ -17,7 +17,7 @@ pub(crate) enum MultiPlexedRecord<'a> {
     /// If the queue does not exists, creates it.
     ///
     /// `position` is the position of the NEXT message to be appended.
-    Touch { queue: &'a str, position: u64 },
+    RecordPosition { queue: &'a str, position: u64 },
     DeleteQueue {
         queue: &'a str,
         position: u64, //< not useful tbh
@@ -83,7 +83,7 @@ impl<'a> Serializable<'a> for MultiPlexedRecord<'a> {
             MultiPlexedRecord::Truncate { queue, position } => {
                 serialize(RecordType::Truncate, position, queue, &[], buffer);
             }
-            MultiPlexedRecord::Touch { queue, position } => {
+            MultiPlexedRecord::RecordPosition { queue, position } => {
                 serialize(RecordType::Touch, position, queue, &[], buffer);
             }
             MultiPlexedRecord::DeleteQueue { position, queue } => {
@@ -108,7 +108,7 @@ impl<'a> Serializable<'a> for MultiPlexedRecord<'a> {
                 records: MultiRecord::new(payload).ok()?,
             }),
             RecordType::Truncate => Some(MultiPlexedRecord::Truncate { queue, position }),
-            RecordType::Touch => Some(MultiPlexedRecord::Touch { queue, position }),
+            RecordType::Touch => Some(MultiPlexedRecord::RecordPosition { queue, position }),
             RecordType::DeleteQueue => Some(MultiPlexedRecord::DeleteQueue { queue, position }),
         }
     }

--- a/src/recordlog/writer.rs
+++ b/src/recordlog/writer.rs
@@ -2,7 +2,7 @@ use tokio::io;
 
 use crate::block_read_write::VecBlockWriter;
 use crate::frame::{FrameType, FrameWriter};
-use crate::rolling::{FileNumber, RollingWriter};
+use crate::rolling::{Directory, FileNumber, RollingWriter};
 use crate::{BlockWrite, Serializable};
 
 pub struct RecordWriter<W> {
@@ -82,8 +82,8 @@ impl<W: BlockWrite + Unpin> RecordWriter<W> {
 }
 
 impl RecordWriter<RollingWriter> {
-    pub async fn gc(&mut self) -> io::Result<()> {
-        self.frame_writer.gc().await
+    pub fn directory(&mut self) -> &mut Directory {
+        self.frame_writer.directory()
     }
 
     pub fn current_file(&mut self) -> &FileNumber {

--- a/src/rolling/file_number.rs
+++ b/src/rolling/file_number.rs
@@ -18,6 +18,8 @@ impl FileTracker {
     }
 
     /// Remove the oldest tracked file if it is no longer used
+    ///
+    /// By design the last file is always considered used.
     pub fn take_first_unused(&mut self) -> Option<FileNumber> {
         // correctness note: this takes a &mut self, so we know there can't be a &FileNumber
         // referencing inside self while this is called.

--- a/src/rolling/tests.rs
+++ b/src/rolling/tests.rs
@@ -179,16 +179,16 @@ async fn test_directory_truncate() {
         assert_eq!(&writer.list_file_numbers(), &[0, 1, 2, 3]);
         assert!(!file_0.can_be_deleted());
         drop(file_1);
-        writer.gc().await.unwrap();
+        writer.directory.gc().await.unwrap();
         assert_eq!(&writer.list_file_numbers(), &[0, 1, 2, 3]);
         drop(file_0);
-        writer.gc().await.unwrap();
+        writer.directory.gc().await.unwrap();
         assert_eq!(&writer.list_file_numbers(), &[2, 3]);
         drop(file_2);
-        writer.gc().await.unwrap();
+        writer.directory.gc().await.unwrap();
         assert_eq!(&writer.list_file_numbers(), &[3]);
         drop(file_3);
-        writer.gc().await.unwrap();
+        writer.directory.gc().await.unwrap();
         assert_eq!(&writer.list_file_numbers(), &[3]);
     }
 }


### PR DESCRIPTION
MemQueue do not hold a reference to the last file that records their position anymore.

Instead, we just rely on the fact that we always log the position of empty mem queues before deleting a file.

Also contrary to the previous behavior, we do not do that always right before GC. We do this only if GC will actually trigger the deletion of at least one file.