### PR TITLE
free up some memory when a queue is too sparse

### DIFF
--- a/src/mem/queue.rs
+++ b/src/mem/queue.rs
@@ -22,11 +22,14 @@ impl RollingBuffer {
     }
 
     fn clear(&mut self) {
-        self.buffer.clear()
+        self.buffer.clear();
+        self.buffer.shrink_to_fit();
     }
 
     fn drain_start(&mut self, pos: usize) {
+        let before_len = self.len();
         self.buffer.drain(..pos);
+        self.buffer.shrink_to(before_len * 9 / 8);
     }
 
     fn extend(&mut self, slice: &[u8]) {


### PR DESCRIPTION
this should work okay with a queue that gets used less than it was before, however for a queue that was very used and is suddenly not used at all, (truncate is done on a full queue, it empties the queue entirely, the queue never gets filed afterward), the queue will keep using its full capacity.