### PR TITLE
Switch record_payloads to bytes::Buf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ tokio = {version="1", features=["io-util", "macros", "rt-multi-thread", "fs", "i
 async-trait = "0.1"
 serde = {version= "1", features=["derive"]}
 serde_json = {version= "1"}
+bytes = {version = "1"}
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/multi_record_log.rs
+++ b/src/multi_record_log.rs
@@ -4,6 +4,8 @@ use std::ops::RangeBounds;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use bytes::Buf;
+
 use crate::error::{
     AppendError, CreateQueueError, DeleteQueueError, ReadRecordError, TruncateError,
 };
@@ -174,7 +176,7 @@ impl MultiRecordLog {
         &mut self,
         queue: &str,
         position_opt: Option<u64>,
-        payload: &[u8],
+        payload: impl Buf,
     ) -> Result<Option<u64>, AppendError> {
         self.append_records(queue, position_opt, std::iter::once(payload))
             .await
@@ -186,7 +188,7 @@ impl MultiRecordLog {
     /// However this function succeeding does not necessarily means records where stored, be sure
     /// to call [`Self::sync`] to make sure changes are persisted if you don't use
     /// [`SyncPolicy::OnAppend`] (which is the default).
-    pub async fn append_records<'a, T: Iterator<Item = &'a [u8]>>(
+    pub async fn append_records<'a, T: Iterator<Item = impl Buf>>(
         &mut self,
         queue: &str,
         position_opt: Option<u64>,

--- a/src/proptests.rs
+++ b/src/proptests.rs
@@ -304,7 +304,7 @@ async fn test_multi_record() {
         multi_record_log.create_queue("queue").await.unwrap();
         assert_eq!(
             multi_record_log
-                .append_record("queue", None, b"1")
+                .append_record("queue", None, &b"1"[..])
                 .await
                 .unwrap(),
             Some(0)
@@ -314,7 +314,7 @@ async fn test_multi_record() {
         let mut multi_record_log = MultiRecordLog::open(tempdir.path()).await.unwrap();
         assert_eq!(
             multi_record_log
-                .append_record("queue", None, b"22")
+                .append_record("queue", None, &b"22"[..])
                 .await
                 .unwrap(),
             Some(1)
@@ -335,7 +335,7 @@ async fn test_multi_record() {
         let mut multi_record_log = MultiRecordLog::open(tempdir.path()).await.unwrap();
         assert_eq!(
             multi_record_log
-                .append_record("queue", None, b"hello")
+                .append_record("queue", None, &b"hello"[..])
                 .await
                 .unwrap(),
             Some(2)

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,5 +1,7 @@
 use std::convert::{TryFrom, TryInto};
 
+use bytes::Buf;
+
 use crate::error::MultiRecordCorruption;
 use crate::Serializable;
 
@@ -141,7 +143,7 @@ impl<'a> MultiRecord<'a> {
         }
     }
 
-    pub fn serialize<'b, T: Iterator<Item = &'b [u8]>>(
+    pub fn serialize<T: Iterator<Item = impl Buf>>(
         record_payloads: T,
         position: u64,
         output: &mut Vec<u8>,
@@ -149,17 +151,22 @@ impl<'a> MultiRecord<'a> {
         Self::serialize_with_pos((position..).zip(record_payloads), output);
     }
 
-    fn serialize_with_pos<'b>(
-        record_payloads: impl Iterator<Item = (u64, &'b [u8])>,
+    fn serialize_with_pos(
+        record_payloads: impl Iterator<Item = (u64, impl Buf)>,
         output: &mut Vec<u8>,
     ) {
         output.clear();
-        for (position, record_payload) in record_payloads {
-            assert!(record_payload.len() <= u32::MAX as usize);
+        for (position, mut record_payload) in record_payloads {
+            assert!(record_payload.remaining() <= u32::MAX as usize);
             // TODO add assert for position monotonicity?
+            let record_payload = &mut record_payload;
             output.extend_from_slice(&position.to_le_bytes());
-            output.extend_from_slice(&(record_payload.len() as u32).to_le_bytes());
-            output.extend_from_slice(record_payload);
+            output.extend_from_slice(&(record_payload.remaining() as u32).to_le_bytes());
+            while record_payload.remaining() > 0 {
+                let chunk = record_payload.chunk();
+                output.extend_from_slice(record_payload.chunk());
+                record_payload.advance(chunk.len());
+            }
         }
     }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -162,7 +162,7 @@ impl<'a> MultiRecord<'a> {
             let record_payload = &mut record_payload;
             output.extend_from_slice(&position.to_le_bytes());
             output.extend_from_slice(&(record_payload.remaining() as u32).to_le_bytes());
-            while record_payload.remaining() > 0 {
+            while record_payload.has_remaining() {
                 let chunk = record_payload.chunk();
                 output.extend_from_slice(record_payload.chunk());
                 record_payload.advance(chunk.len());


### PR DESCRIPTION
Switches record_payloads internface from using &'b [u8] to bytes::Buf.

Closes #29