### PR TITLE
undo make contiguous

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "mrecordlog"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
+rust-version = "1.68" # 1.67 contains an UB we would trigger
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/mem/queue.rs
+++ b/src/mem/queue.rs
@@ -27,13 +27,9 @@ impl RollingBuffer {
     }
 
     fn drain_start(&mut self, pos: usize) {
-        let target_capacity = self.len() * 9 / 8;
+        let before_len = self.len();
         self.buffer.drain(..pos);
-        // TODO this is a workarround for https://github.com/rust-lang/rust/issues/108453
-        if self.buffer.capacity() > target_capacity {
-            self.buffer.make_contiguous();
-            self.buffer.shrink_to(target_capacity);
-        }
+        self.buffer.shrink_to(before_len * 9 / 8);
     }
 
     fn extend(&mut self, slice: &[u8]) {


### PR DESCRIPTION
we no longer need it as 1.68 is out, and `make_contiguous` is quite expensive (approximately as much as the previous Vec based implementation, except we pay approximately once every other truncate)

I've added a MSRV to make sure nobody uses this crate when it can trigger UB