### PR TITLE
try to recover from corruption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = "0.1"
 serde = {version= "1", features=["derive"]}
 serde_json = {version= "1"}
 bytes = {version = "1"}
+tracing = "0.1.37"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,10 +34,6 @@ impl From<MissingQueue> for DeleteQueueError {
 }
 
 #[derive(Debug, Error)]
-#[error("TouchError")]
-pub struct TouchError;
-
-#[derive(Debug, Error)]
 #[error("MultiRecordCorruption")]
 pub struct MultiRecordCorruption;
 
@@ -53,8 +49,6 @@ pub enum TruncateError {
     MissingQueue(String),
     #[error("Io error: {0}")]
     IoError(#[from] io::Error),
-    #[error("Touch error: {0}")]
-    TouchError(#[from] TouchError),
     #[error("Future position forbidden")]
     Future,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,8 +49,6 @@ pub enum TruncateError {
     MissingQueue(String),
     #[error("Io error: {0}")]
     IoError(#[from] io::Error),
-    #[error("Future position forbidden")]
-    Future,
 }
 
 impl From<MissingQueue> for TruncateError {
@@ -67,8 +65,6 @@ pub enum AppendError {
     MissingQueue(String),
     #[error("Past")]
     Past,
-    #[error("Future")]
-    Future,
 }
 
 impl From<MissingQueue> for AppendError {

--- a/src/mem/queue.rs
+++ b/src/mem/queue.rs
@@ -258,7 +258,7 @@ impl MemQueue {
             .drain_start(start_offset_to_keep)
             .await;
         self.start_position = truncate_up_to_pos + 1;
-        return first_record_to_keep;
+        first_record_to_keep
     }
 
     pub fn size(&self) -> usize {

--- a/src/mem/queue.rs
+++ b/src/mem/queue.rs
@@ -245,6 +245,8 @@ impl MemQueue {
                 first_record_to_keep
             } else {
                 // clear the queue entirely
+                // TODO it might make more sense to jump to truncate_up_to_pos instead of just
+                // going on step forward.
                 self.start_position = self.next_position();
                 self.concatenated_records.clear();
                 self.record_metas.clear();

--- a/src/mem/queues.rs
+++ b/src/mem/queues.rs
@@ -44,13 +44,15 @@ impl MemQueues {
         &self,
         queue: &str,
         range: R,
-    ) -> Option<impl Iterator<Item = (u64, Cow<[u8]>)> + '_>
+    ) -> Result<impl Iterator<Item = (u64, Cow<[u8]>)> + '_, MissingQueue>
     where
         R: RangeBounds<u64> + 'static,
     {
-        // We do not rely on `entry` in order to avoid
-        // the allocation.
-        Some(self.queues.get(queue)?.range(range))
+        if let Some(queue) = self.queues.get(queue) {
+            Ok(queue.range(range))
+        } else {
+            Err(MissingQueue(queue.to_string()))
+        }
     }
 
     fn get_queue(&self, queue: &str) -> Result<&MemQueue, MissingQueue> {

--- a/src/mem/queues.rs
+++ b/src/mem/queues.rs
@@ -133,9 +133,11 @@ impl MemQueues {
     ///
     /// If there are no records `<= position`, the method will
     /// not do anything.
-    pub async fn truncate(&mut self, queue: &str, position: u64) {
+    pub async fn truncate(&mut self, queue: &str, position: u64) -> Option<usize> {
         if let Ok(queue) = self.get_queue_mut(queue) {
-            queue.truncate(position).await;
+            Some(queue.truncate(position).await)
+        } else {
+            None
         }
     }
 

--- a/src/mem/queues.rs
+++ b/src/mem/queues.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::RangeBounds;
 
-use crate::error::{AlreadyExists, AppendError, MissingQueue, TouchError};
+use crate::error::{AlreadyExists, AppendError, MissingQueue};
 use crate::mem::MemQueue;
 use crate::rolling::FileNumber;
 
@@ -92,10 +92,12 @@ impl MemQueues {
 
     /// Ensure that the queue is empty and start_position = next_position.
     ///
-    /// Returns an error if the queue already exists and contains elements,
-    /// or is empty but has a next_position that does not match.
-    pub fn ack_position(&mut self, queue: &str, next_position: u64) -> Result<(), TouchError> {
-        if let Some(queue) = self.queues.get(queue) {
+    /// If the queue doesn't exist, create it. If it does, but isn't empty or the position doesn't
+    /// match, truncate it and make it go forward to the requested position.
+    ///
+    /// This operation is meant only to rebuild the in memory queue from its on-disk state.
+    pub fn ack_position(&mut self, queue_name: &str, next_position: u64) {
+        if let Some(queue) = self.queues.get(queue_name) {
             // It is possible for `ack_position` to be called when a queue already exists.
             //
             // For instance, we may have recorded the position of an empty stale queue
@@ -104,16 +106,22 @@ impl MemQueues {
             // Another possibility is if an IO error occured right after recording position
             // and before deleting files.
             if !queue.is_empty() || queue.next_position() != next_position {
-                return Err(TouchError);
+                // if we are here, some updates to the queue were lost/corrupted, but it's no
+                // big deal as they were no longer considered part of the active state. We can
+                // delete and recreate the queue to put it in the expected state.
+                self.queues.remove(queue_name);
+                self.queues.insert(
+                    queue_name.to_string(),
+                    MemQueue::with_next_position(next_position),
+                );
             }
         } else {
             // The queue does not exist! Let's create it and set the right `next_position`.
             self.queues.insert(
-                queue.to_string(),
+                queue_name.to_string(),
                 MemQueue::with_next_position(next_position),
             );
         }
-        Ok(())
     }
 
     pub fn next_position(&self, queue: &str) -> Result<u64, MissingQueue> {
@@ -122,12 +130,9 @@ impl MemQueues {
 
     /// Removes records up to the supplied `position`,
     /// including the position itself.
-    //
+    ///
     /// If there are no records `<= position`, the method will
     /// not do anything.
-    ///
-    /// If one or more files should be removed,
-    /// returns the range of the files that should be removed
     pub async fn truncate(&mut self, queue: &str, position: u64) {
         if let Ok(queue) = self.get_queue_mut(queue) {
             queue.truncate(position).await;

--- a/src/mem/tests.rs
+++ b/src/mem/tests.rs
@@ -256,7 +256,7 @@ async fn test_mem_queues_kee_filenum() {
     assert_eq!(empty_queues.len(), 1);
     assert_eq!(empty_queues[0].0, "droopy");
 
-    mem_queues.ack_position("droopy", 5).unwrap();
+    mem_queues.ack_position("droopy", 5);
 
     assert!(files[2].can_be_deleted());
 }

--- a/src/mem/tests.rs
+++ b/src/mem/tests.rs
@@ -110,35 +110,52 @@ async fn test_mem_queues_truncate() {
 }
 
 #[tokio::test]
-async fn test_mem_queues_skip_yield_error() {
+async fn test_mem_queues_skip_advance() {
     let mut mem_queues = MemQueues::default();
     mem_queues.create_queue("droopy").unwrap();
     assert!(mem_queues
         .append_record("droopy", &1.into(), 0, b"hello")
         .await
         .is_ok());
-    let append_res = mem_queues
+    assert!(mem_queues
         .append_record("droopy", &1.into(), 2, b"happy")
-        .await;
-    assert!(matches!(append_res, Err(AppendError::Future)));
-    assert!(matches!(
-        mem_queues
-            .append_record("droopy", &1.into(), 3, b"happy")
-            .await,
-        Err(AppendError::Future)
-    ));
+        .await
+        .is_ok());
+    assert!(mem_queues
+        .append_record("droopy", &1.into(), 3, b"happy")
+        .await
+        .is_ok());
     assert!(mem_queues
         .append_record("droopy", &1.into(), 1, b"happy")
         .await
-        .is_ok());
+        .is_err());
     let droopy: Vec<(u64, Cow<[u8]>)> = mem_queues.range("droopy", 0..).unwrap().collect();
     assert_eq!(
         &droopy[..],
         &[
             (0, Cow::Borrowed(&b"hello"[..])),
-            (1, Cow::Borrowed(&b"happy"[..]))
+            (2, Cow::Borrowed(&b"happy"[..])),
+            (3, Cow::Borrowed(&b"happy"[..])),
         ]
     );
+    let droopy: Vec<(u64, Cow<[u8]>)> = mem_queues.range("droopy", 1..).unwrap().collect();
+    assert_eq!(
+        &droopy[..],
+        &[
+            (2, Cow::Borrowed(&b"happy"[..])),
+            (3, Cow::Borrowed(&b"happy"[..])),
+        ]
+    );
+    let droopy: Vec<(u64, Cow<[u8]>)> = mem_queues.range("droopy", 2..).unwrap().collect();
+    assert_eq!(
+        &droopy[..],
+        &[
+            (2, Cow::Borrowed(&b"happy"[..])),
+            (3, Cow::Borrowed(&b"happy"[..])),
+        ]
+    );
+    let droopy: Vec<(u64, Cow<[u8]>)> = mem_queues.range("droopy", 3..).unwrap().collect();
+    assert_eq!(&droopy[..], &[(3, Cow::Borrowed(&b"happy"[..])),]);
 }
 
 #[tokio::test]
@@ -193,7 +210,7 @@ async fn test_mem_queues_non_zero_first_el() {
 }
 
 #[tokio::test]
-async fn test_mem_queues_kee_filenum() {
+async fn test_mem_queues_keep_filenum() {
     let mut mem_queues = MemQueues::default();
 
     let files = (0..4).map(FileNumber::for_test).collect::<Vec<_>>();

--- a/src/multi_record_log.rs
+++ b/src/multi_record_log.rs
@@ -8,7 +8,7 @@ use bytes::Buf;
 use tracing::warn;
 
 use crate::error::{
-    AppendError, CreateQueueError, DeleteQueueError, ReadRecordError, TruncateError,
+    AppendError, CreateQueueError, DeleteQueueError, MissingQueue, ReadRecordError, TruncateError,
 };
 use crate::mem;
 use crate::record::{MultiPlexedRecord, MultiRecord};
@@ -291,7 +291,7 @@ impl MultiRecordLog {
         &self,
         queue: &str,
         range: R,
-    ) -> Option<impl Iterator<Item = (u64, Cow<[u8]>)> + '_>
+    ) -> Result<impl Iterator<Item = (u64, Cow<[u8]>)> + '_, MissingQueue>
     where
         R: RangeBounds<u64> + 'static,
     {

--- a/src/rolling/file_number.rs
+++ b/src/rolling/file_number.rs
@@ -161,6 +161,7 @@ mod tests {
     #[test]
     fn test_file_number_with_clone_cannot_be_deleted() {
         let file = FileNumber::default();
+        #[allow(clippy::redundant_clone)]
         let _file_clone = file.clone();
         assert!(!file.can_be_deleted());
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -388,7 +388,8 @@ async fn test_open_corrupted() {
         let mut file = OpenOptions::new().write(true).open(file.path()).unwrap();
         // jump somewhere in the middle
         file.seek(SeekFrom::Start(10240)).unwrap();
-        file.write(b"this will corrupt the file. Good :-)").unwrap();
+        file.write_all(b"this will corrupt the file. Good :-)")
+            .unwrap();
     }
     {
         let multi_record_log = MultiRecordLog::open(tempdir.path()).await.unwrap();


### PR DESCRIPTION
when reading queue from disk, handle errors when a block is corrupted. Incidentally, this requires fixing #4 as queues can end up sparse if some of their records got deleted.

related to quickwit-oss/quickwit#3589

There isn't tests to test the recovery process, and limited tests for non contiguous positions. I'd like to add some before this get merged, but unless tests show surprising results, the code should be ready for review.