### PR TITLE
persist on create queue

### DIFF
--- a/src/multi_record_log.rs
+++ b/src/multi_record_log.rs
@@ -116,7 +116,7 @@ impl MultiRecordLog {
         }
         let record = MultiPlexedRecord::RecordPosition { queue, position: 0 };
         self.record_log_writer.write_record(record)?;
-        self.persist_on_policy()?;
+        self.persist(PersistAction::FlushAndFsync)?;
         self.in_mem_queues.create_queue(queue)?;
         Ok(())
     }


### PR DESCRIPTION
source of CI failure in https://github.com/quickwit-oss/quickwit/pull/4804
(the queue isn't persisted, and mrecordlog is closed and reopened)